### PR TITLE
Add universal webhook testing app

### DIFF
--- a/universal_app/README.md
+++ b/universal_app/README.md
@@ -1,0 +1,17 @@
+# Universal Testing App
+
+This application provides a simple webhook based API to create tests and collect responses.
+
+## Features
+* Import questions from a GIFT formatted text file
+* Question types supported: single choice, text answer and matching
+* Assign random questions to users from the pool
+* Submit answers and get correctness feedback
+
+## API Endpoints
+* `/webhook/import` – POST JSON `{ "file": "path/to/file.gift" }`
+* `/webhook/create_user` – POST JSON `{ "username": "user1" }`
+* `/webhook/assign` – POST JSON `{ "user_id": 1, "count": 5 }`
+* `/webhook/submit` – POST JSON `{ "user_id": 1, "answers": {assignment_id: answer} }`
+
+Database connection parameters are taken from environment variables similar to other lessons.

--- a/universal_app/flask_app/app/CreateDb.py
+++ b/universal_app/flask_app/app/CreateDb.py
@@ -1,0 +1,5 @@
+from . import app
+from .models import db
+
+with app.app_context():
+    db.create_all()

--- a/universal_app/flask_app/app/SetUsers.py
+++ b/universal_app/flask_app/app/SetUsers.py
@@ -1,0 +1,23 @@
+import uuid
+import random
+from .models import db, User, Question, Assignment
+from . import app
+
+random.seed()
+
+def create_session_user(username):
+    with app.app_context():
+        user = User(username=username)
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+def assign_random_questions(user_id, count=5):
+    with app.app_context():
+        q_ids = [q.id for q in Question.query.all()]
+        random.shuffle(q_ids)
+        for q_id in q_ids[:count]:
+            assign = Assignment(user_id=user_id, question_id=q_id)
+            db.session.add(assign)
+        db.session.commit()
+

--- a/universal_app/flask_app/app/__init__.py
+++ b/universal_app/flask_app/app/__init__.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from .models import db
+from ..config import path, db_host, db_port, db_user, db_pass, db_name, SECRET_KEY
+from os.path import join as pjoin
+from os import environ
+
+def create_app():
+    app = Flask(__name__)
+    if environ.get('FLASK_ENV') == 'production':
+        app.config['SQLALCHEMY_DATABASE_URI'] = f'mysql+pymysql://{db_user}:{db_pass}@{db_host}:{db_port}/{db_name}'
+    else:
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + pjoin(path, 'tmp', 'universal.db')
+    app.config['SECRET_KEY'] = SECRET_KEY
+    db.init_app(app)
+    return app
+
+app = create_app()
+
+from . import routes

--- a/universal_app/flask_app/app/models.py
+++ b/universal_app/flask_app/app/models.py
@@ -1,0 +1,33 @@
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+db = SQLAlchemy()
+
+class User(db.Model):
+    __tablename__ = 'users'
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(128), unique=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+class Question(db.Model):
+    __tablename__ = 'questions'
+    id = db.Column(db.Integer, primary_key=True)
+    text = db.Column(db.Text, nullable=False)
+    qtype = db.Column(db.String(32), nullable=False)
+
+class Option(db.Model):
+    __tablename__ = 'options'
+    id = db.Column(db.Integer, primary_key=True)
+    question_id = db.Column(db.Integer, db.ForeignKey('questions.id'), nullable=False)
+    text = db.Column(db.Text, nullable=False)
+    is_correct = db.Column(db.Boolean, default=False)
+    match_key = db.Column(db.String(64), nullable=True)
+    order_pos = db.Column(db.Integer, nullable=True)
+
+class Assignment(db.Model):
+    __tablename__ = 'assignments'
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    question_id = db.Column(db.Integer, db.ForeignKey('questions.id'), nullable=False)
+    answered = db.Column(db.Boolean, default=False)
+    correct = db.Column(db.Boolean, default=False)

--- a/universal_app/flask_app/app/routes.py
+++ b/universal_app/flask_app/app/routes.py
@@ -1,0 +1,72 @@
+from flask import request, jsonify
+from . import app
+from .models import db, User, Question, Option, Assignment
+from .utils import import_gift
+import random
+
+@app.route('/webhook/import', methods=['POST'])
+def webhook_import():
+    file_path = request.json.get('file')
+    if not file_path:
+        return jsonify({'error': 'file field required'}), 400
+    import_gift(file_path)
+    return jsonify({'status': 'ok'})
+
+@app.route('/webhook/create_user', methods=['POST'])
+def create_user():
+    username = request.json.get('username')
+    if not username:
+        return jsonify({'error': 'username required'}), 400
+    user = User(username=username)
+    db.session.add(user)
+    db.session.commit()
+    return jsonify({'id': user.id})
+
+@app.route('/webhook/assign', methods=['POST'])
+def assign_questions():
+    user_id = request.json.get('user_id')
+    count = request.json.get('count', 5)
+    user = User.query.get(user_id)
+    if not user:
+        return jsonify({'error': 'user not found'}), 404
+    q_ids = [q.id for q in Question.query.all()]
+    random.shuffle(q_ids)
+    for q_id in q_ids[:count]:
+        assignment = Assignment(user_id=user.id, question_id=q_id)
+        db.session.add(assignment)
+    db.session.commit()
+    return jsonify({'assigned': count})
+
+@app.route('/webhook/submit', methods=['POST'])
+def submit():
+    data = request.json
+    user_id = data.get('user_id')
+    answers = data.get('answers', {})
+    results = []
+    for assign_id, ans in answers.items():
+        assignment = Assignment.query.get(assign_id)
+        if not assignment:
+            continue
+        question = Question.query.get(assignment.question_id)
+        correct = check_answer(question, ans)
+        assignment.answered = True
+        assignment.correct = correct
+        results.append({'id': assign_id, 'correct': correct})
+    db.session.commit()
+    return jsonify({'results': results})
+
+def check_answer(question, ans):
+    if question.qtype == 'text':
+        option = Option.query.filter_by(question_id=question.id).first()
+        return option.text.strip().lower() == str(ans).strip().lower()
+    elif question.qtype == 'single':
+        opt = Option.query.filter_by(question_id=question.id, is_correct=True).first()
+        return str(ans) == str(opt.id)
+    elif question.qtype == 'matching':
+        pairs = Option.query.filter_by(question_id=question.id).all()
+        for p in pairs:
+            if p.text not in ans or ans[p.text] != p.match_key:
+                return False
+        return True
+    return False
+

--- a/universal_app/flask_app/app/utils.py
+++ b/universal_app/flask_app/app/utils.py
@@ -1,0 +1,51 @@
+import re
+from .models import db, Question, Option
+
+QUESTION_RE = re.compile(r"(?P<text>.*)\{(?P<body>.*)\}", re.DOTALL)
+
+def import_gift(file_path):
+    with open(file_path, encoding='utf-8') as f:
+        content = f.read()
+
+    for block in content.split('\n\n'):
+        block = block.strip()
+        if not block:
+            continue
+        m = QUESTION_RE.search(block)
+        if not m:
+            continue
+        text = m.group('text').strip()
+        body = m.group('body').strip()
+        parse_question(text, body)
+    db.session.commit()
+
+def parse_question(text, body):
+    if '->' in body and '=' in body:
+        qtype = 'matching'
+        pairs = [p.strip() for p in body.split('=') if p.strip()]
+        q = Question(text=text, qtype=qtype)
+        db.session.add(q)
+        db.session.flush()
+        for pair in pairs:
+            left, right = pair.split('->')
+            opt = Option(question_id=q.id, text=left.strip(), is_correct=True, match_key=right.strip())
+            db.session.add(opt)
+        return
+    if body.count('=') > 1 or '~' in body:
+        qtype = 'single'
+        q = Question(text=text, qtype=qtype)
+        db.session.add(q)
+        db.session.flush()
+        parts = re.split(r'[=~]', body)
+        signs = [c for c in body if c in '=~']
+        for sign, part in zip(signs, parts[1:]):
+            opt = Option(question_id=q.id, text=part.strip(), is_correct=(sign=='='))
+            db.session.add(opt)
+        return
+    qtype = 'text'
+    q = Question(text=text, qtype=qtype)
+    db.session.add(q)
+    db.session.flush()
+    opt = Option(question_id=q.id, text=body.strip(), is_correct=True)
+    db.session.add(opt)
+

--- a/universal_app/flask_app/config.py
+++ b/universal_app/flask_app/config.py
@@ -1,0 +1,9 @@
+from os import getcwd, environ
+
+path = getcwd()
+db_host = environ.get('DB_HOST', 'localhost')
+db_port = environ.get('DB_PORT', '3306')
+db_user = environ.get('DB_USER', 'universal')
+db_pass = environ.get('DB_PASSWORD', 'universal')
+db_name = environ.get('DB_DATABASE', 'universal')
+SECRET_KEY = environ.get('SECRET_KEY', 'secret')

--- a/universal_app/flask_app/run.py
+++ b/universal_app/flask_app/run.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run()

--- a/universal_app/requirements.txt
+++ b/universal_app/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy


### PR DESCRIPTION
## Summary
- add universal app with Flask that supports creating test questions via webhook
- parse GIFT files to populate the database
- assign questions to users and submit answers using webhook API

## Testing
- `python -m py_compile universal_app/flask_app/app/*.py universal_app/flask_app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2331b2b4832b9b3bf1045b6255bf