### PR TITLE
Add GIFT question pools

### DIFF
--- a/universal_app/README.md
+++ b/universal_app/README.md
@@ -1,0 +1,18 @@
+# Universal Testing App
+
+This application provides a simple webhook based API to create tests and collect responses.
+
+## Features
+* Import questions from a GIFT formatted text file
+* Supports `// QuestionNumber:` tag for grouping questions into random pools
+* Question types supported: single choice, multiple choice, text answer and matching
+* Assign random questions to each user from every available pool
+* Submit answers and get correctness feedback
+
+## API Endpoints
+* `/webhook/import` – POST JSON `{ "file": "path/to/file.gift" }`
+* `/webhook/create_user` – POST JSON `{ "username": "user1" }`
+* `/webhook/assign` – POST JSON `{ "user_id": 1, "count": 5 }`
+* `/webhook/submit` – POST JSON `{ "user_id": 1, "answers": {assignment_id: answer} }`
+
+Database connection parameters are taken from environment variables similar to other lessons.

--- a/universal_app/flask_app/app/CreateDb.py
+++ b/universal_app/flask_app/app/CreateDb.py
@@ -1,0 +1,5 @@
+from . import app
+from .models import db
+
+with app.app_context():
+    db.create_all()

--- a/universal_app/flask_app/app/SetQuestions.py
+++ b/universal_app/flask_app/app/SetQuestions.py
@@ -1,0 +1,13 @@
+from . import app
+from .models import db, Question
+from .utils import import_gift
+from os import environ
+
+GIFT_FILE = environ.get('GIFT_FILE', 'questions.gift')
+
+with app.app_context():
+    if Question.query.count() == 0 and GIFT_FILE:
+        try:
+            import_gift(GIFT_FILE)
+        except FileNotFoundError:
+            pass

--- a/universal_app/flask_app/app/SetUsers.py
+++ b/universal_app/flask_app/app/SetUsers.py
@@ -1,0 +1,45 @@
+import random
+import string
+from .models import db, User, Session, Question, Assignment
+from . import app
+
+random.seed()
+
+def set_user_session(part: int):
+    with app.app_context():
+        number = db.session.query(db.func.max(Session.number)).scalar() or 0
+        number += 1
+        session = Session(number=number, part=part)
+        db.session.add(session)
+        db.session.commit()
+        return number
+
+def _generate_username(length: int) -> str:
+    letters = string.ascii_lowercase
+    digits = string.digits
+    word = ''.join(random.choice(letters) for _ in range(length - 3))
+    return word + ''.join(random.choice(digits) for _ in range(3))
+
+def make_user(session_number: int, first_last_name: str):
+    with app.app_context():
+        session_obj = Session.query.filter_by(number=session_number).first()
+        if not session_obj:
+            raise ValueError('session not found')
+
+        pools = sorted({q.pool for q in Question.query.all()})
+        username = _generate_username(10)
+        user = User(username=username, first_last_name=first_last_name, session=session_obj)
+        db.session.add(user)
+        db.session.flush()
+
+        for pool in pools:
+            q_ids = [q.id for q in Question.query.filter_by(pool=pool).all()]
+            if not q_ids:
+                continue
+            q_id = random.choice(q_ids)
+            assign = Assignment(user_id=user.id, question_id=q_id)
+            db.session.add(assign)
+
+        db.session.commit()
+        return username
+

--- a/universal_app/flask_app/app/__init__.py
+++ b/universal_app/flask_app/app/__init__.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from .models import db
+from ..config import path, db_host, db_port, db_user, db_pass, db_name, SECRET_KEY
+from os.path import join as pjoin
+from os import environ
+
+def create_app():
+    app = Flask(__name__)
+    if environ.get('FLASK_ENV') == 'production':
+        app.config['SQLALCHEMY_DATABASE_URI'] = f'mysql+pymysql://{db_user}:{db_pass}@{db_host}:{db_port}/{db_name}'
+    else:
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + pjoin(path, 'tmp', 'universal.db')
+    app.config['SECRET_KEY'] = SECRET_KEY
+    db.init_app(app)
+    return app
+
+app = create_app()
+
+from . import CreateDb, SetQuestions, routes

--- a/universal_app/flask_app/app/models.py
+++ b/universal_app/flask_app/app/models.py
@@ -1,0 +1,45 @@
+from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
+
+db = SQLAlchemy()
+
+
+class Session(db.Model):
+    __tablename__ = 'sessions'
+    id = db.Column(db.Integer, primary_key=True)
+    number = db.Column(db.Integer, unique=True, nullable=False)
+    part = db.Column(db.Integer, nullable=False, default=0)
+
+class User(db.Model):
+    __tablename__ = 'users'
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(128), unique=True, nullable=False)
+    first_last_name = db.Column(db.String(128), nullable=False)
+    session_id = db.Column(db.Integer, db.ForeignKey('sessions.id'), nullable=False)
+    session = db.relationship('Session')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+class Question(db.Model):
+    __tablename__ = 'questions'
+    id = db.Column(db.Integer, primary_key=True)
+    text = db.Column(db.Text, nullable=False)
+    qtype = db.Column(db.String(32), nullable=False)
+    pool = db.Column(db.Integer, nullable=False, default=1)
+
+class Option(db.Model):
+    __tablename__ = 'options'
+    id = db.Column(db.Integer, primary_key=True)
+    question_id = db.Column(db.Integer, db.ForeignKey('questions.id'), nullable=False)
+    text = db.Column(db.Text, nullable=False)
+    is_correct = db.Column(db.Boolean, default=False)
+    match_key = db.Column(db.String(64), nullable=True)
+    order_pos = db.Column(db.Integer, nullable=True)
+
+class Assignment(db.Model):
+    __tablename__ = 'assignments'
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    question_id = db.Column(db.Integer, db.ForeignKey('questions.id'), nullable=False)
+    answered = db.Column(db.Boolean, default=False)
+    correct = db.Column(db.Boolean, default=False)
+

--- a/universal_app/flask_app/app/routes.py
+++ b/universal_app/flask_app/app/routes.py
@@ -1,0 +1,76 @@
+from flask import request, jsonify
+from . import app
+from .models import db, User, Question, Option, Assignment, Session
+from .utils import import_gift
+from .SetUsers import make_user
+import random
+
+@app.route('/webhook/import', methods=['POST'])
+def webhook_import():
+    file_path = request.json.get('file')
+    if not file_path:
+        return jsonify({'error': 'file field required'}), 400
+    import_gift(file_path)
+    return jsonify({'status': 'ok'})
+
+@app.route('/webhook/create_user', methods=['POST'])
+def create_user():
+    first_last = request.json.get('first_last_name')
+    session_number = request.json.get('session_number')
+    if not first_last or session_number is None:
+        return jsonify({'error': 'first_last_name and session_number required'}), 400
+    try:
+        username = make_user(session_number, first_last)
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 404
+    user = User.query.filter_by(username=username).first()
+    return jsonify({'id': user.id, 'username': username})
+
+@app.route('/webhook/assign', methods=['POST'])
+def assign_questions():
+    user_id = request.json.get('user_id')
+    count = request.json.get('count', 5)
+    user = User.query.get(user_id)
+    if not user:
+        return jsonify({'error': 'user not found'}), 404
+    q_ids = [q.id for q in Question.query.all()]
+    random.shuffle(q_ids)
+    for q_id in q_ids[:count]:
+        assignment = Assignment(user_id=user.id, question_id=q_id)
+        db.session.add(assignment)
+    db.session.commit()
+    return jsonify({'assigned': count})
+
+@app.route('/webhook/submit', methods=['POST'])
+def submit():
+    data = request.json
+    user_id = data.get('user_id')
+    answers = data.get('answers', {})
+    results = []
+    for assign_id, ans in answers.items():
+        assignment = Assignment.query.get(assign_id)
+        if not assignment:
+            continue
+        question = Question.query.get(assignment.question_id)
+        correct = check_answer(question, ans)
+        assignment.answered = True
+        assignment.correct = correct
+        results.append({'id': assign_id, 'correct': correct})
+    db.session.commit()
+    return jsonify({'results': results})
+
+def check_answer(question, ans):
+    if question.qtype == 'text':
+        option = Option.query.filter_by(question_id=question.id).first()
+        return option.text.strip().lower() == str(ans).strip().lower()
+    elif question.qtype == 'single':
+        opt = Option.query.filter_by(question_id=question.id, is_correct=True).first()
+        return str(ans) == str(opt.id)
+    elif question.qtype == 'matching':
+        pairs = Option.query.filter_by(question_id=question.id).all()
+        for p in pairs:
+            if p.text not in ans or ans[p.text] != p.match_key:
+                return False
+        return True
+    return False
+

--- a/universal_app/flask_app/app/utils.py
+++ b/universal_app/flask_app/app/utils.py
@@ -1,0 +1,67 @@
+import re
+from .models import db, Question, Option
+
+QUESTION_NUMBER_RE = re.compile(r"//\s*QuestionNumber:\s*(\d+)", re.IGNORECASE)
+
+QUESTION_RE = re.compile(r"(?P<text>.*)\{(?P<body>.*)\}", re.DOTALL)
+
+def import_gift(file_path):
+    with open(file_path, encoding='utf-8') as f:
+        content = f.read()
+
+    for block in content.split('\n\n'):
+        block = block.strip()
+        if not block:
+            continue
+        lines = block.splitlines()
+        pool = 1
+        if lines and lines[0].startswith('//'):
+            mnum = QUESTION_NUMBER_RE.search(lines[0])
+            if mnum:
+                pool = int(mnum.group(1))
+            lines = lines[1:]
+        block_text = '\n'.join(lines)
+        m = QUESTION_RE.search(block_text)
+        if not m:
+            continue
+        text = m.group('text').strip()
+        body = m.group('body').strip()
+        parse_question(text, body, pool)
+    db.session.commit()
+
+def parse_question(text, body, pool):
+    if '->' in body and '=' in body:
+        qtype = 'matching'
+        pairs = [p.strip() for p in body.split('=') if p.strip()]
+        q = Question(text=text, qtype=qtype, pool=pool)
+        db.session.add(q)
+        db.session.flush()
+        for pair in pairs:
+            left, right = pair.split('->')
+            opt = Option(question_id=q.id, text=left.strip(), is_correct=True, match_key=right.strip())
+            db.session.add(opt)
+        return
+
+    correct_count = body.count('=')
+    if correct_count > 1:
+        qtype = 'multi'
+    elif correct_count == 1 or '~' in body:
+        qtype = 'single'
+    else:
+        qtype = 'text'
+
+    q = Question(text=text, qtype=qtype, pool=pool)
+    db.session.add(q)
+    db.session.flush()
+
+    if qtype in ('single', 'multi'):
+        parts = re.split(r'[=~]', body)
+        signs = [c for c in body if c in '=~']
+        for sign, part in zip(signs, parts[1:]):
+            opt = Option(question_id=q.id, text=part.strip(), is_correct=(sign=='='))
+            db.session.add(opt)
+    elif qtype == 'text':
+        opt = Option(question_id=q.id, text=body.strip(), is_correct=True)
+        db.session.add(opt)
+
+

--- a/universal_app/flask_app/config.py
+++ b/universal_app/flask_app/config.py
@@ -1,0 +1,9 @@
+from os import getcwd, environ
+
+path = getcwd()
+db_host = environ.get('DB_HOST', 'localhost')
+db_port = environ.get('DB_PORT', '3306')
+db_user = environ.get('DB_USER', 'universal')
+db_pass = environ.get('DB_PASSWORD', 'universal')
+db_name = environ.get('DB_DATABASE', 'universal')
+SECRET_KEY = environ.get('SECRET_KEY', 'secret')

--- a/universal_app/flask_app/run.py
+++ b/universal_app/flask_app/run.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == '__main__':
+    app.run()

--- a/universal_app/requirements.txt
+++ b/universal_app/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy


### PR DESCRIPTION
## Summary
- update universal_app to support question pools
- add Session model and store pool numbers
- parse `// QuestionNumber:` comments when importing GIFT files
- assign one random question per pool when creating users
- document the new behaviour

## Testing
- `python -m py_compile universal_app/flask_app/app/*.py universal_app/flask_app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2331b2b4832b9b3bf1045b6255bf